### PR TITLE
Dodano obsługę ścieżek

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,4 +1,4 @@
 [settings]
-path_to_log_file = .\data\
+path_to_log_file = data
 # log_file_name = KopiaZapasowaLOG.txt
 log_file_name = KopiaZapasowaLOG_z_bledem.txt

--- a/runner.py
+++ b/runner.py
@@ -9,11 +9,18 @@ Skrypt zawiera funkcje:
 -----------------------
 - get_configuration_settings() -> tuple[str, str]
     Odczyt pliku konfiguracyjnego
+- get_root_folder() -> pathlib.Path:
+    Pobranie głównego katalogu programu
+- get_config_path(root_folder: pathlib.Path) -> pathlib.Path:
+    Pobranie ścieżki do pliku 'config.ini'
+- get_path_to_log_file(root_folder: pathlib.Path, log_file_path: str, log_file_name: str) -> pathlib.Path:
+    Pobranie ścieżki do pliku logu polecenia 'robocopy'
 - main
     Główna funkcja sterująca przepływem programu
 """
 # Standard library imports
 import configparser
+import pathlib
 
 # Third party imports
 
@@ -26,7 +33,7 @@ def get_configuration_settings(path_to_config_file: str) -> tuple[str, str]:
 
     Funkcja odczytuje dane z pliku konfiguracyjnego
 
-    :param path_to_config_file: Ścieżka do pliki konfiguracyjnego
+    :param path_to_config_file: Ścieżka do pliku konfiguracyjnego
     :type path_to_config_file: str
     :return: Nazwa pliku log, Ścieżka do pliku logu
     :rtype: tuple[str, str]
@@ -48,13 +55,60 @@ def get_configuration_settings(path_to_config_file: str) -> tuple[str, str]:
         raise KeyError(f"W pliku konfiguracyjnym {path_to_config_file} nie znaleziono sekcji 'settings'")
 
 
+def get_root_folder() -> pathlib.Path:
+    """ Pobranie głównego katalogu programu
+
+    Funkcja pobiera główny katalog programu. Katalog jest identyfikowany jako ten, w którym jest uruchamiany plik
+    'runner.py'
+    :return: Ścieżka do głównego katalogu programu
+    :rtype: pathlib.Path
+    """
+    return pathlib.Path(__file__).resolve().parent
+
+
+def get_config_path(root_folder: pathlib.Path) -> pathlib.Path:
+    """ Pobranie ścieżki do pliku 'config.ini'
+
+    Funkcja zwraca ścieżkę do pliku konfiguracyjnego programu.
+
+    :param root_folder: Główny katalog programu. Plik 'config.ini' znajduje się w głównym katalogu programu
+    :type root_folder:
+    :return: Ścieżka do pliku 'config.ini'
+    :rtype: pathlib.Path
+    """
+    return pathlib.Path.joinpath(root_folder, 'config.ini')
+
+
+def get_path_to_log_file(root_folder: pathlib.Path, log_file_path: str, log_file_name: str) -> pathlib.Path:
+    """ Pobranie ścieżki do pliku logu polecenia 'robocopy'
+    Funkcja na podstawie podanych informacji, buduje ścieżkę do pliku z logiem polecenia 'robocopy'
+
+    :param root_folder: Główny folder programu
+    :type root_folder: pathlib.Path
+    :param log_file_path: Ścieżka do katalogu w którym znajduje się plik logu
+    :type log_file_path: str
+    :param log_file_name: Nazwa pliku logu
+    :type log_file_name: str
+    :return: Ścieżka do pliku logu polecenia 'robocopy'
+    :rtype: pathlib.Path
+    """
+    return pathlib.Path.joinpath(root_folder, log_file_path, log_file_name)
+
+
 def main():
     """ Główna funkcja sterująca przepływem programu.
 
     Funkcja uruchamia odczyt danych z pliku logu, następnie uruchamia wyświetlenie podsumowania.
     """
-    log_file_name, log_file_path = get_configuration_settings('config.ini')
-    robocopy_list = read_log_file(log_file_path + log_file_name)
+    # Pobranie ścieżki do pliku config.ini
+    root_folder = get_root_folder()
+    config_path = get_config_path(root_folder)
+
+    # Pobranie ścieżki do pliku logu z polecenia 'robocopy'
+    log_file_name, log_file_path = get_configuration_settings(str(config_path))
+    full_path_to_log_file = get_path_to_log_file(root_folder, log_file_path, log_file_name)
+
+    robocopy_list = read_log_file(str(full_path_to_log_file))
 
     # Wyświetlenie raportu
     message: str = ''

--- a/tests/runner_test.py
+++ b/tests/runner_test.py
@@ -13,7 +13,10 @@ Funkcje:
     Jeżeli nie znaleziono pliku konfiguracyjnego to zwracany jest wyjątek FileNotFoundError
 - test_get_configuration_settings_if_file_not_found_get_error():
     Jeżeli nie znaleziono sekcji 'settings' w pliku konfiguracyjnym to zwracany jest wyjątek
-
+- test_get_config_path():
+    Jeżeli podano ścieżkę do katalogu to funkcja powinna dodać do niego pliki o nazwie 'config.ini
+- test_get_path_to_log_file():
+    Jeżeli podano prawidłowe dane to funkcja powinna zwrócić ścieżkę zbudowaną z podanych danych wejściowych
 
 Wyjątki:
 --------
@@ -21,6 +24,7 @@ Wyjątki:
 """
 
 # Standard library imports
+import pathlib
 
 # Third party imports
 import pytest
@@ -64,3 +68,21 @@ def test_get_configuration_settings_if_no_key_get_error():
     path_to_file = '.\\data\\test_config_without_key.ini'
     with pytest.raises(KeyError):
         runner.get_configuration_settings(path_to_file)
+
+
+def test_get_config_path():
+    """
+    Jeżeli podano ścieżkę do katalogu to funkcja powinna dodać do niego pliki o nazwie 'config.ini
+    """
+    folder = pathlib.Path(__file__).resolve().parent
+    config_file = pathlib.Path.joinpath(folder, 'config.ini')
+    assert config_file == runner.get_config_path(folder)
+
+
+def test_get_path_to_log_file():
+    """
+    Jeżeli podano prawidłowe dane to funkcja powinna zwrócić ścieżkę zbudowaną z podanych danych wejściowych
+    """
+    folder = pathlib.Path(__file__).resolve().parent
+    log_file = pathlib.Path.joinpath(folder, 'katalog_z_danymi', 'plik_logu.log')
+    assert log_file == runner.get_path_to_log_file(folder, 'katalog_z_danymi', 'plik_logu.log')


### PR DESCRIPTION
Program jest teraz niezależny od katalogu, z którego został uruchomiony. Wcześniej można było uruchomić program tylko z katalogu, w którym znajduje się plik 'runner.py'. W innym przypadku pojawiał się błąd związany z nieprawidłową ścieżką do pliku 'config.ini' oraz pliku log polecenia 'robocopy'